### PR TITLE
Implement data ingestion chunking and hybrid indexing

### DIFF
--- a/data_ingestion/__init__.py
+++ b/data_ingestion/__init__.py
@@ -1,0 +1,22 @@
+"""High level helpers for data ingestion."""
+from __future__ import annotations
+
+from .loader import (
+    Document,
+    DocumentLoader,
+    chunk_text,
+    clean_text,
+    load_documents,
+    load_documents_from_paths,
+    save_documents,
+)
+
+__all__ = [
+    "Document",
+    "DocumentLoader",
+    "chunk_text",
+    "clean_text",
+    "load_documents",
+    "load_documents_from_paths",
+    "save_documents",
+]

--- a/data_ingestion/loader.py
+++ b/data_ingestion/loader.py
@@ -1,87 +1,219 @@
-"""Utilities for loading documents from various sources."""
+"""Utilities for loading and preprocessing documents for retrieval."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Dict, Iterable, List, Optional
-
+import json
 import logging
+import re
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Sequence
 
-try:
+try:  # pragma: no cover - handled via optional dependency in requirements
     from markdown2 import markdown
-except ImportError:  # pragma: no cover - dependency handled via requirements
+except ImportError:  # pragma: no cover
     markdown = None  # type: ignore
 
-try:
-    from pypdf import PdfReader
+try:  # pragma: no cover - dependency declared in requirements
+    from PyPDF2 import PdfReader
 except ImportError:  # pragma: no cover
-    PdfReader = None  # type: ignore
+    try:  # pragma: no cover - fallback to pypdf which offers the same API
+        from pypdf import PdfReader  # type: ignore
+    except ImportError:  # pragma: no cover
+        PdfReader = None  # type: ignore
+
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class Document:
-    """In-memory representation of a document."""
+    """In-memory representation of a processed document chunk."""
 
     doc_id: str
     content: str
     metadata: Dict[str, str] = field(default_factory=dict)
 
+    def to_json(self) -> Dict[str, str]:
+        """Return a JSON-serialisable representation of the document."""
+
+        return {
+            "doc_id": self.doc_id,
+            "content": self.content,
+            "metadata": self.metadata,
+        }
+
+    @staticmethod
+    def from_json(payload: Dict[str, str]) -> "Document":
+        """Instantiate a document from a JSON payload."""
+
+        return Document(
+            doc_id=payload["doc_id"],
+            content=payload["content"],
+            metadata=dict(payload.get("metadata", {})),
+        )
+
 
 class DocumentLoader:
-    """Load documents from common file formats."""
+    """Load documents from disk and chunk them into retrieval friendly units."""
 
-    def __init__(self, base_path: Path | str):
+    SUPPORTED_EXTENSIONS = {".pdf", ".md", ".markdown", ".txt", ""}
+
+    def __init__(
+        self,
+        base_path: Path | str,
+        *,
+        chunk_size: int = 500,
+        chunk_overlap: int = 50,
+    ) -> None:
         self.base_path = Path(base_path)
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be greater than zero")
+        if self.chunk_overlap < 0:
+            raise ValueError("chunk_overlap must not be negative")
+        if self.chunk_overlap >= self.chunk_size:
+            logger.warning(
+                "chunk_overlap (%s) >= chunk_size (%s); overlap will be clamped",
+                self.chunk_overlap,
+                self.chunk_size,
+            )
 
     def load(self) -> List[Document]:
-        """Recursively load all supported documents under ``base_path``."""
+        """Recursively load and chunk all supported documents under ``base_path``."""
+
+        if not self.base_path.exists():
+            raise FileNotFoundError(f"Data directory {self.base_path} does not exist")
         documents: List[Document] = []
-        for path in self.base_path.rglob("*"):
-            if path.is_file():
-                doc = self._load_file(path)
-                if doc:
-                    documents.append(doc)
+        for path in sorted(self.base_path.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in self.SUPPORTED_EXTENSIONS:
+                logger.debug("Skipping unsupported file type: %s", path)
+                continue
+            try:
+                documents.extend(self._load_file(path))
+            except Exception as exc:  # pragma: no cover - logged for observability
+                logger.exception("Failed to load %s: %s", path, exc)
         return documents
 
-    def _load_file(self, path: Path) -> Optional[Document]:
+    def _load_file(self, path: Path) -> List[Document]:
         suffix = path.suffix.lower()
         if suffix == ".pdf":
-            return self._load_pdf(path)
-        if suffix in {".md", ".markdown"}:
-            return self._load_markdown(path)
-        if suffix in {".txt", ""}:
-            return self._load_text(path)
-        logger.debug("Skipping unsupported file type: %s", path)
-        return None
+            text = self._read_pdf(path)
+        elif suffix in {".md", ".markdown"}:
+            text = self._read_markdown(path)
+        else:
+            text = self._read_text(path)
+        return list(self._chunk_document(path, text))
 
-    def _load_text(self, path: Path) -> Document:
-        content = path.read_text(encoding="utf-8")
-        return Document(doc_id=str(path.relative_to(self.base_path)), content=content, metadata={"source": str(path)})
+    def _read_text(self, path: Path) -> str:
+        return path.read_text(encoding="utf-8")
 
-    def _load_markdown(self, path: Path) -> Document:
+    def _read_markdown(self, path: Path) -> str:
         raw = path.read_text(encoding="utf-8")
         if markdown is None:
             logger.warning("markdown2 not installed, returning raw Markdown text")
-            content = raw
-        else:
-            content = markdown(raw)
-        return Document(doc_id=str(path.relative_to(self.base_path)), content=content, metadata={"source": str(path), "format": "markdown"})
+            return raw
+        html = markdown(raw)
+        # Strip HTML tags to provide cleaner text for downstream components.
+        return re.sub(r"<[^>]+>", " ", html)
 
-    def _load_pdf(self, path: Path) -> Document:
+    def _read_pdf(self, path: Path) -> str:
         if PdfReader is None:
-            raise ImportError("pypdf is required to load PDF files")
+            raise ImportError("PyPDF2 or pypdf is required to load PDF files")
         reader = PdfReader(str(path))
         pages = [page.extract_text() or "" for page in reader.pages]
-        content = "\n".join(pages)
-        return Document(doc_id=str(path.relative_to(self.base_path)), content=content, metadata={"source": str(path), "format": "pdf"})
+        return "\n".join(pages)
+
+    def _chunk_document(self, path: Path, text: str) -> Iterator[Document]:
+        clean = clean_text(text)
+        if not clean:
+            return iter(())
+        doc_id = self._relative_id(path)
+        title = path.stem
+
+        def _generator() -> Iterator[Document]:
+            for idx, chunk in enumerate(chunk_text(clean, self.chunk_size, self.chunk_overlap)):
+                chunk_id = f"{doc_id}::chunk_{idx}"
+                yield Document(
+                    doc_id=chunk_id,
+                    content=chunk,
+                    metadata={
+                        "title": title,
+                        "source": str(path),
+                        "chunk_id": chunk_id,
+                        "document_id": doc_id,
+                    },
+                )
+
+        return _generator()
+
+    def _relative_id(self, path: Path) -> str:
+        try:
+            return str(path.relative_to(self.base_path))
+        except ValueError:  # pragma: no cover - defensive guard
+            return str(path)
 
 
-def load_documents_from_paths(paths: Iterable[Path | str]) -> List[Document]:
+def clean_text(text: str) -> str:
+    """Normalise whitespace and strip leading/trailing spaces."""
+
+    text = text.replace("\u00a0", " ")
+    text = re.sub(r"[\r\t]+", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def chunk_text(text: str, chunk_size: int, chunk_overlap: int) -> Iterator[str]:
+    """Split ``text`` into overlapping word-based chunks."""
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be greater than zero")
+    if chunk_overlap < 0:
+        raise ValueError("chunk_overlap must not be negative")
+    words = text.split()
+    if not words:
+        return iter(())
+    overlap = min(chunk_overlap, chunk_size - 1) if chunk_size > 1 else 0
+    step = max(1, chunk_size - overlap)
+    start = 0
+    def _generator() -> Iterator[str]:
+        nonlocal start
+        while start < len(words):
+            end = start + chunk_size
+            chunk_words = words[start:end]
+            if not chunk_words:
+                break
+            yield " ".join(chunk_words)
+            start += step
+
+    return _generator()
+
+
+def load_documents_from_paths(
+    paths: Iterable[Path | str], *, chunk_size: int = 500, chunk_overlap: int = 50
+) -> List[Document]:
     """Load documents from a heterogeneous collection of paths."""
+
     documents: List[Document] = []
     for path in paths:
-        loader = DocumentLoader(path)
+        loader = DocumentLoader(path, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
         documents.extend(loader.load())
     return documents
+
+
+def save_documents(documents: Sequence[Document], destination: Path | str) -> None:
+    """Persist a list of documents to disk for reproducibility."""
+
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = [doc.to_json() for doc in documents]
+    destination.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def load_documents(path: Path | str) -> List[Document]:
+    """Load pre-processed documents saved via :func:`save_documents`."""
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [Document.from_json(item) for item in data]

--- a/indexing/__init__.py
+++ b/indexing/__init__.py
@@ -1,0 +1,6 @@
+"""Indexing package exports."""
+from __future__ import annotations
+
+from .index import BM25Index, HybridIndex, RetrievalResult, VectorIndex
+
+__all__ = ["BM25Index", "HybridIndex", "RetrievalResult", "VectorIndex"]

--- a/indexing/index.py
+++ b/indexing/index.py
@@ -1,0 +1,447 @@
+"""Indexing utilities for dense, sparse, and hybrid retrieval."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections import Counter
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency handled via requirements
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover
+    faiss = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency handled via requirements
+    import numpy as np
+except Exception:  # pragma: no cover
+    np = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency handled via requirements
+    from rank_bm25 import BM25Okapi
+except Exception:  # pragma: no cover
+    BM25Okapi = None  # type: ignore
+
+from data_ingestion.loader import Document
+from .embedder import BaseEmbedder, HashingEmbedder, SentenceTransformerEmbedder
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetrievalResult:
+    """Structured representation of a retrieval match."""
+
+    document: Document
+    score: float
+    dense_score: Optional[float] = None
+    sparse_score: Optional[float] = None
+
+
+class VectorIndex:
+    """FAISS-backed dense retrieval index."""
+
+    def __init__(
+        self,
+        embedder: Optional[BaseEmbedder] = None,
+        *,
+        use_faiss: Optional[bool] = None,
+        normalize: bool = True,
+    ) -> None:
+        self.embedder = embedder or _default_embedder()
+        self.normalize = normalize
+        self.use_faiss = self._resolve_faiss_flag(use_faiss)
+        self._documents: List[Document] = []
+        self._faiss_index = None
+        self._normalized_embeddings = None
+
+    @staticmethod
+    def _resolve_faiss_flag(flag: Optional[bool]) -> bool:
+        if flag is None:
+            return faiss is not None and np is not None
+        if flag and (faiss is None or np is None):
+            raise ImportError("FAISS and numpy are required when use_faiss=True")
+        return flag
+
+    @property
+    def documents(self) -> Sequence[Document]:
+        return self._documents
+
+    def build(self, documents: Sequence[Document]) -> None:
+        """Build the dense index from ``documents``."""
+
+        if not documents:
+            raise ValueError("Cannot build an index with zero documents")
+        self._documents = list(documents)
+        if self.use_faiss:
+            if np is None:
+                raise ImportError("numpy is required for FAISS indexing")
+            matrix = self._embed_texts([doc.content for doc in self._documents])
+            if matrix.size == 0:
+                raise ValueError("Embedder returned no embeddings")
+            if self.normalize:
+                matrix = _normalize_matrix(matrix)
+            dimension = matrix.shape[1]
+            self._faiss_index = faiss.IndexFlatIP(dimension)  # type: ignore[arg-type]
+            self._faiss_index.add(matrix)
+        else:
+            embeddings = list(self.embedder.embed([doc.content for doc in self._documents]))
+            if not embeddings:
+                raise ValueError("Embedder returned no embeddings")
+            vectors = [_ensure_float_list(vec) for vec in embeddings]
+            if self.normalize:
+                vectors = [_normalize_list(vec) for vec in vectors]
+            self._normalized_embeddings = vectors
+
+    def query(self, text: str, top_k: int = 5) -> List[RetrievalResult]:
+        """Return the ``top_k`` most similar documents for ``text``."""
+
+        if not self._documents:
+            raise RuntimeError("Index has not been built")
+        query_embeddings = list(self.embedder.embed([text]))
+        if not query_embeddings:
+            return []
+        if self.use_faiss:
+            if self._faiss_index is None:
+                raise RuntimeError("FAISS index has not been built")
+            if np is None:
+                raise ImportError("numpy is required for FAISS indexing")
+            query_matrix = self._embed_texts([text])
+            if self.normalize:
+                query_matrix = _normalize_matrix(query_matrix)
+            scores, indices = self._faiss_index.search(query_matrix, top_k)  # type: ignore[arg-type]
+        else:
+            if self._normalized_embeddings is None:
+                raise RuntimeError("Index has not been built")
+            query_vector = _ensure_float_list(query_embeddings[0])
+            if self.normalize:
+                query_vector = _normalize_list(query_vector)
+            scores, indices = _brute_force_cosine_list(self._normalized_embeddings, query_vector, top_k)
+        results: List[RetrievalResult] = []
+        for score, index in zip(scores[0], indices[0]):
+            if index == -1:
+                continue
+            document = self._documents[int(index)]
+            results.append(RetrievalResult(document=document, score=float(score), dense_score=float(score)))
+        return results
+
+    def save(self, directory: Path | str) -> None:
+        """Persist the index to ``directory``."""
+
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        docs_payload = [doc.to_json() for doc in self._documents]
+        (path / "documents.json").write_text(json.dumps(docs_payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        config = {
+            "normalize": self.normalize,
+            "use_faiss": self.use_faiss,
+            "embedder": self._serialize_embedder(),
+        }
+        if self.use_faiss:
+            config["embedding_format"] = "faiss"
+        else:
+            config["embedding_format"] = "json"
+            embeddings = self._normalized_embeddings
+            if embeddings is None:
+                raise RuntimeError("Index has not been built")
+            (path / "embeddings.json").write_text(json.dumps(embeddings, ensure_ascii=False), encoding="utf-8")
+        (path / "config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+        if self.use_faiss:
+            if self._faiss_index is None:
+                raise RuntimeError("FAISS index has not been built")
+            faiss.write_index(self._faiss_index, str(path / "index.faiss"))  # type: ignore[arg-type]
+
+    @classmethod
+    def load(
+        cls,
+        directory: Path | str,
+        *,
+        embedder: Optional[BaseEmbedder] = None,
+    ) -> "VectorIndex":
+        """Load an index previously saved with :meth:`save`."""
+
+        path = Path(directory)
+        config = json.loads((path / "config.json").read_text(encoding="utf-8"))
+        embedder = embedder or _deserialize_embedder(config.get("embedder"))
+        index = cls(embedder=embedder, use_faiss=config.get("use_faiss", True), normalize=config.get("normalize", True))
+        documents = [Document.from_json(item) for item in json.loads((path / "documents.json").read_text(encoding="utf-8"))]
+        index._documents = documents
+        if index.use_faiss:
+            if faiss is None:
+                raise ImportError("faiss is required to load a FAISS-backed index")
+            index._faiss_index = faiss.read_index(str(path / "index.faiss"))  # type: ignore[arg-type]
+        else:
+            fmt = config.get("embedding_format", "json")
+            if fmt == "json":
+                data = json.loads((path / "embeddings.json").read_text(encoding="utf-8"))
+                index._normalized_embeddings = [[float(value) for value in vector] for vector in data]
+            elif fmt == "npy":
+                if np is None:
+                    raise ImportError("numpy is required to load embeddings saved in npy format")
+                index._normalized_embeddings = np.load(path / "embeddings.npy").tolist()
+            else:
+                raise ValueError(f"Unsupported embedding format: {fmt}")
+        return index
+
+    def _embed_texts(self, texts: Iterable[str]) -> "np.ndarray":
+        if np is None:
+            raise ImportError("numpy is required for dense indexing")
+        matrix = np.asarray(list(self.embedder.embed(texts)), dtype=np.float32)
+        if matrix.ndim != 2:
+            raise ValueError("Embeddings must be a 2D matrix")
+        return matrix
+
+    def _serialize_embedder(self) -> Dict[str, str]:
+        if isinstance(self.embedder, SentenceTransformerEmbedder):
+            model_name = getattr(self.embedder.model, "name_or_path", "")
+            return {"type": "sentence-transformer", "model_name": model_name}
+        if isinstance(self.embedder, HashingEmbedder):
+            return {"type": "hashing", "dim": getattr(self.embedder, "dim", 256)}
+        return {"type": self.embedder.__class__.__name__}
+
+
+class BM25Index:
+    """Sparse BM25 index built with :mod:`rank_bm25`."""
+
+    def __init__(self, tokenizer: Optional[Callable[[str], List[str]]] = None) -> None:
+        self.tokenizer = tokenizer or _default_tokenizer
+        self._documents: List[Document] = []
+        self._tokenized_corpus: List[List[str]] = []
+        self._model = None
+
+    @property
+    def documents(self) -> Sequence[Document]:
+        return self._documents
+
+    def build(self, documents: Sequence[Document]) -> None:
+        if not documents:
+            raise ValueError("Cannot build an index with zero documents")
+        self._documents = list(documents)
+        self._tokenized_corpus = [self.tokenizer(doc.content) for doc in self._documents]
+        if BM25Okapi is not None and np is not None:
+            self._model = BM25Okapi(self._tokenized_corpus)
+        else:
+            self._model = None
+
+    def query(self, text: str, top_k: int = 5) -> List[RetrievalResult]:
+        tokens = self.tokenizer(text)
+        if self._model is not None and np is not None:
+            scores = self._model.get_scores(tokens)
+            ranked_indices = np.argsort(scores)[::-1][:top_k]
+            results: List[RetrievalResult] = []
+            for idx in ranked_indices:
+                results.append(
+                    RetrievalResult(
+                        document=self._documents[int(idx)],
+                        score=float(scores[idx]),
+                        sparse_score=float(scores[idx]),
+                    )
+                )
+            return results
+        return self._fallback_search(tokens, top_k)
+
+    def _fallback_search(self, tokens: List[str], top_k: int) -> List[RetrievalResult]:
+        if not self._documents:
+            return []
+        query_counts = Counter(tokens)
+        scored: List[Tuple[int, float]] = []
+        for idx, doc_tokens in enumerate(self._tokenized_corpus):
+            doc_counts = Counter(doc_tokens)
+            score = float(sum(query_counts[token] * doc_counts.get(token, 0) for token in query_counts))
+            scored.append((idx, score))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        results: List[RetrievalResult] = []
+        for idx, score in scored[:top_k]:
+            results.append(
+                RetrievalResult(
+                    document=self._documents[idx],
+                    score=score,
+                    sparse_score=score,
+                )
+            )
+        return results
+
+    def save(self, directory: Path | str) -> None:
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "documents": [doc.to_json() for doc in self._documents],
+        }
+        (path / "bm25.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(
+        cls,
+        directory: Path | str,
+        *,
+        tokenizer: Optional[Callable[[str], List[str]]] = None,
+    ) -> "BM25Index":
+        path = Path(directory)
+        payload = json.loads((path / "bm25.json").read_text(encoding="utf-8"))
+        documents = [Document.from_json(item) for item in payload.get("documents", [])]
+        index = cls(tokenizer=tokenizer)
+        if documents:
+            index.build(documents)
+        return index
+
+
+class HybridIndex:
+    """Combine dense and sparse indexes for hybrid retrieval."""
+
+    def __init__(
+        self,
+        vector_index: Optional[VectorIndex] = None,
+        bm25_index: Optional[BM25Index] = None,
+        *,
+        dense_weight: float = 0.5,
+        sparse_weight: float = 0.5,
+    ) -> None:
+        if not 0.0 <= dense_weight <= 1.0:
+            raise ValueError("dense_weight must be between 0 and 1")
+        if not 0.0 <= sparse_weight <= 1.0:
+            raise ValueError("sparse_weight must be between 0 and 1")
+        if dense_weight == 0.0 and sparse_weight == 0.0:
+            raise ValueError("At least one of dense_weight or sparse_weight must be non-zero")
+        self.vector_index = vector_index or VectorIndex()
+        self.bm25_index = bm25_index or BM25Index()
+        self.dense_weight = dense_weight
+        self.sparse_weight = sparse_weight
+
+    def build(self, documents: Sequence[Document]) -> None:
+        if not documents:
+            raise ValueError("Cannot build an index with zero documents")
+        self.vector_index.build(documents)
+        self.bm25_index.build(documents)
+
+    def query(self, text: str, top_k: int = 5) -> List[RetrievalResult]:
+        dense_results = self.vector_index.query(text, top_k=top_k)
+        sparse_results = self.bm25_index.query(text, top_k=top_k)
+        score_map: Dict[str, RetrievalResult] = {}
+
+        def _accumulate(results: Iterable[RetrievalResult], weight: float, attr: str) -> None:
+            for result in results:
+                doc_id = result.document.doc_id
+                base = score_map.get(doc_id)
+                if base is None:
+                    base = RetrievalResult(document=result.document, score=0.0)
+                    score_map[doc_id] = base
+                score = getattr(result, attr) if getattr(result, attr) is not None else result.score
+                if attr == "dense_score":
+                    base.dense_score = score
+                else:
+                    base.sparse_score = score
+                base.score += weight * score
+
+        _accumulate(dense_results, self.dense_weight, "dense_score")
+        _accumulate(sparse_results, self.sparse_weight, "sparse_score")
+        ranked = sorted(score_map.values(), key=lambda item: item.score, reverse=True)
+        return ranked[:top_k]
+
+    def save(self, directory: Path | str) -> None:
+        path = Path(directory)
+        self.vector_index.save(path / "dense")
+        self.bm25_index.save(path / "bm25")
+        config = {
+            "dense_weight": self.dense_weight,
+            "sparse_weight": self.sparse_weight,
+        }
+        (path / "config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(
+        cls,
+        directory: Path | str,
+        *,
+        embedder: Optional[BaseEmbedder] = None,
+        tokenizer: Optional[Callable[[str], List[str]]] = None,
+    ) -> "HybridIndex":
+        path = Path(directory)
+        config = json.loads((path / "config.json").read_text(encoding="utf-8"))
+        vector_index = VectorIndex.load(path / "dense", embedder=embedder)
+        bm25_index = BM25Index.load(path / "bm25", tokenizer=tokenizer)
+        return cls(
+            vector_index=vector_index,
+            bm25_index=bm25_index,
+            dense_weight=config.get("dense_weight", 0.5),
+            sparse_weight=config.get("sparse_weight", 0.5),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _default_embedder() -> BaseEmbedder:
+    try:
+        return SentenceTransformerEmbedder()
+    except Exception:  # pragma: no cover - fall back to hashing embedder for lightweight usage
+        logger.warning("Falling back to HashingEmbedder due to SentenceTransformer availability issues")
+        return HashingEmbedder()
+
+
+def _normalize_matrix(matrix: "np.ndarray") -> "np.ndarray":
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+def _ensure_float_list(vector: Iterable[float]) -> List[float]:
+    if isinstance(vector, list):
+        return [float(value) for value in vector]
+    if hasattr(vector, "tolist"):
+        converted = vector.tolist()
+        if isinstance(converted, list):
+            return [float(value) for value in converted]
+        return [float(converted)]
+    return [float(value) for value in vector]
+
+
+def _normalize_list(vector: Sequence[float]) -> List[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0.0:
+        return [0.0 for value in vector]
+    return [float(value) / norm for value in vector]
+
+
+def _brute_force_cosine_list(
+    embeddings: Sequence[Sequence[float]], query: Sequence[float], top_k: int
+) -> Tuple[List[List[float]], List[List[int]]]:
+    scores = [_dot(vector, query) for vector in embeddings]
+    ranked_indices = sorted(range(len(scores)), key=lambda idx: scores[idx], reverse=True)[:top_k]
+    top_scores = [scores[idx] for idx in ranked_indices]
+    while len(top_scores) < top_k:
+        ranked_indices.append(-1)
+        top_scores.append(-1.0)
+    return [top_scores], [ranked_indices]
+
+
+def _dot(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
+    return float(sum(a * b for a, b in zip(vec_a, vec_b)))
+
+
+def _default_tokenizer(text: str) -> List[str]:
+    return text.lower().split()
+
+
+def _deserialize_embedder(config: Optional[Dict[str, str]]) -> BaseEmbedder:
+    if not config:
+        return _default_embedder()
+    if config.get("type") == "sentence-transformer":
+        model_name = config.get("model_name") or "sentence-transformers/all-MiniLM-L6-v2"
+        return SentenceTransformerEmbedder(model_name)
+    if config.get("type") == "hashing":
+        dim = int(config.get("dim", 256))
+        return HashingEmbedder(dim=dim)
+    logger.warning("Unknown embedder type %s, using default", config.get("type"))
+    return _default_embedder()
+
+
+__all__ = [
+    "BM25Index",
+    "HybridIndex",
+    "RetrievalResult",
+    "VectorIndex",
+]

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -1,12 +1,79 @@
+from __future__ import annotations
+
+from io import BytesIO
 from pathlib import Path
+from typing import List
+
+import pytest
 
 from data_ingestion.loader import DocumentLoader
 
 
-def test_load_text(tmp_path: Path) -> None:
-    file_path = tmp_path / "doc.txt"
-    file_path.write_text("Hello world", encoding="utf-8")
-    loader = DocumentLoader(tmp_path)
+def _create_pdf_bytes(text: str) -> bytes:
+    """Create a minimal PDF document containing ``text``."""
+
+    buffer = BytesIO()
+    buffer.write(b"%PDF-1.4\n")
+    offsets: List[int] = []
+
+    def _write_obj(obj_num: int, content: bytes) -> None:
+        offsets.append(buffer.tell())
+        buffer.write(f"{obj_num} 0 obj\n".encode("utf-8"))
+        buffer.write(content)
+        buffer.write(b"\nendobj\n")
+
+    _write_obj(1, b"<< /Type /Catalog /Pages 2 0 R >>")
+    _write_obj(2, b"<< /Type /Pages /Count 1 /Kids [3 0 R] >>")
+    _write_obj(
+        3,
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>",
+    )
+    stream = f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET".encode("utf-8")
+    _write_obj(4, b"<< /Length " + str(len(stream)).encode("utf-8") + b" >>\nstream\n" + stream + b"\nendstream")
+    _write_obj(5, b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    xref_offset = buffer.tell()
+    buffer.write(f"xref\n0 {len(offsets) + 1}\n".encode("utf-8"))
+    buffer.write(b"0000000000 65535 f \n")
+    for offset in offsets:
+        buffer.write(f"{offset:010d} 00000 n \n".encode("utf-8"))
+    buffer.write(b"trailer\n<< /Size ")
+    buffer.write(str(len(offsets) + 1).encode("utf-8"))
+    buffer.write(b" /Root 1 0 R >>\nstartxref\n")
+    buffer.write(str(xref_offset).encode("utf-8"))
+    buffer.write(b"\n%%EOF")
+    return buffer.getvalue()
+
+
+def test_load_text_file_with_chunking(tmp_path: Path) -> None:
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("one two three four five six", encoding="utf-8")
+    loader = DocumentLoader(tmp_path, chunk_size=3, chunk_overlap=1)
     docs = loader.load()
-    assert len(docs) == 1
-    assert docs[0].content == "Hello world"
+    assert len(docs) == 3
+    assert docs[0].content == "one two three"
+    assert docs[0].metadata["chunk_id"].endswith("chunk_0")
+    assert docs[0].metadata["title"] == "sample"
+
+
+def test_load_markdown_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "readme.md"
+    file_path.write_text("# Title\n\nThis is *markdown* content.", encoding="utf-8")
+    loader = DocumentLoader(tmp_path, chunk_size=10, chunk_overlap=2)
+    docs = loader.load()
+    assert docs
+    assert "this is" in docs[0].content.lower()
+    assert docs[0].metadata["source"] == str(file_path)
+
+
+def test_load_pdf_file(tmp_path: Path) -> None:
+    pytest.importorskip("PyPDF2")
+    pdf_bytes = _create_pdf_bytes("Hello PDF world")
+    pdf_path = tmp_path / "document.pdf"
+    pdf_path.write_bytes(pdf_bytes)
+    loader = DocumentLoader(tmp_path, chunk_size=50)
+    docs = loader.load()
+    assert docs
+    assert any("hello" in doc.content.lower() for doc in docs)
+    assert docs[0].metadata["source"] == str(pdf_path)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,15 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
 from data_ingestion.loader import Document
 from indexing.embedder import HashingEmbedder
-from indexing.vector_store import FaissVectorStore
+from indexing.index import BM25Index, HybridIndex, VectorIndex
 
 
-def test_faiss_vector_store_build_and_search() -> None:
-    docs = [
-        Document(doc_id="1", content="Python programming"),
-        Document(doc_id="2", content="Machine learning"),
+@pytest.fixture()
+def sample_documents() -> List[Document]:
+    return [
+        Document(doc_id="doc::chunk_0", content="python programming language", metadata={"title": "doc"}),
+        Document(doc_id="doc::chunk_1", content="machine learning and statistics", metadata={"title": "doc"}),
+        Document(doc_id="doc::chunk_2", content="deep learning with python", metadata={"title": "doc"}),
     ]
-    store = FaissVectorStore(embedder=HashingEmbedder(), use_faiss=False)
-    store.build(docs)
-    results = store.search("Python", k=1)
+
+
+def test_vector_index_build_query_and_persist(tmp_path: Path, sample_documents: List[Document]) -> None:
+    index = VectorIndex(embedder=HashingEmbedder(dim=64), use_faiss=False)
+    index.build(sample_documents)
+    results = index.query("python", top_k=2)
     assert results
-    assert results[0][0].doc_id == "1"
+    assert any("python" in result.document.content for result in results)
+
+    save_path = tmp_path / "vector"
+    index.save(save_path)
+    loaded = VectorIndex.load(save_path, embedder=HashingEmbedder(dim=64))
+    loaded_results = loaded.query("python", top_k=2)
+    assert loaded_results[0].document.doc_id == results[0].document.doc_id
+
+
+def test_bm25_index_build_and_query(sample_documents: List[Document]) -> None:
+    index = BM25Index()
+    index.build(sample_documents)
+    results = index.query("statistics", top_k=1)
+    assert results
+    assert "statistics" in results[0].document.content
+
+
+def test_hybrid_index_combines_scores(sample_documents: List[Document]) -> None:
+    hybrid = HybridIndex(
+        vector_index=VectorIndex(embedder=HashingEmbedder(dim=64), use_faiss=False),
+        dense_weight=0.7,
+        sparse_weight=0.3,
+    )
+    hybrid.build(sample_documents)
+    results = hybrid.query("python learning", top_k=3)
+    assert results
+    # Ensure results include both dense and sparse contributions
+    assert any(result.dense_score is not None for result in results)
+    assert any(result.sparse_score is not None for result in results)
+
+
+def test_hybrid_index_persistence(tmp_path: Path, sample_documents: List[Document]) -> None:
+    hybrid = HybridIndex(vector_index=VectorIndex(embedder=HashingEmbedder(dim=32), use_faiss=False))
+    hybrid.build(sample_documents)
+    hybrid.save(tmp_path)
+
+    loaded = HybridIndex.load(tmp_path, embedder=HashingEmbedder(dim=32))
+    results = loaded.query("python", top_k=1)
+    assert results
+    assert "python" in results[0].document.content

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
+from data_ingestion.loader import DocumentLoader
 from generation.dummy import EchoGenerator
-from indexing.embedder import get_default_embedder
+from indexing.embedder import get_default_embedder, HashingEmbedder
+from indexing.index import HybridIndex, VectorIndex
 from pipelines.chatbot import RAGPipeline
 
 
@@ -21,3 +23,25 @@ def test_end_to_end_query(tmp_path: Path) -> None:
     assert docs
     response = pipeline.chat("Python", top_k=1)
     assert "Python" in response
+
+
+def test_loader_and_index_integration(tmp_path: Path) -> None:
+    data_dir = tmp_path / "dataset"
+    data_dir.mkdir()
+    (data_dir / "doc1.txt").write_text("Python enables rapid application development", encoding="utf-8")
+    (data_dir / "doc2.md").write_text("## Heading\n\nRust focuses on performance.", encoding="utf-8")
+
+    loader = DocumentLoader(data_dir, chunk_size=20)
+    documents = loader.load()
+    assert documents
+
+    index = HybridIndex(
+        vector_index=VectorIndex(embedder=HashingEmbedder(dim=64), use_faiss=False),
+        dense_weight=0.6,
+        sparse_weight=0.4,
+    )
+    index.build(documents)
+
+    results = index.query("rapid development", top_k=2)
+    assert results
+    assert any("python" in result.document.content.lower() for result in results)


### PR DESCRIPTION
## Summary
- add a chunking document loader that normalises text from PDF, Markdown, and text files while preserving metadata
- introduce vector, BM25, and hybrid indexing utilities with save/load support for dense and sparse retrieval
- expand unit and integration tests to cover loaders, indexing persistence, and hybrid querying

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68deaa9ed5fc832296964b5676aa25d1