### PR TITLE
Implement dual-stage PRF retrieval and coverage-aware reranking

### DIFF
--- a/reranking/__init__.py
+++ b/reranking/__init__.py
@@ -1,0 +1,18 @@
+"""Reranking components used for ordering retrieved documents."""
+from __future__ import annotations
+
+from typing import Protocol, Sequence, Tuple
+
+from data_ingestion.loader import Document
+
+
+class RerankerProtocol(Protocol):
+    """Protocol describing a reranker implementation."""
+
+    def rerank(self, candidates: Sequence[Tuple[Document, float]], top_k: int = 5):
+        """Return a reranked subset of ``candidates``."""
+
+
+from .coverage import CoverageAwareReranker
+
+__all__ = ["RerankerProtocol", "CoverageAwareReranker"]

--- a/reranking/coverage.py
+++ b/reranking/coverage.py
@@ -1,7 +1,8 @@
 """Coverage-aware reranking implementation."""
 from __future__ import annotations
 
-from typing import Callable, Iterable, List, Sequence, Tuple
+from collections import defaultdict
+from typing import Callable, Dict, List, Sequence, Tuple
 
 from data_ingestion.loader import Document
 
@@ -14,16 +15,63 @@ def default_coverage(doc: Document) -> float:
     return float(len(doc.content.split()))
 
 
-class CoverageReranker:
-    """Rerank retrieved documents based on coverage signals."""
+class CoverageAwareReranker:
+    """Combine semantic similarity with coverage and diversity signals."""
 
-    def __init__(self, coverage_fn: CoverageFunction | None = None):
+    def __init__(
+        self,
+        coverage_fn: CoverageFunction | None = None,
+        *,
+        similarity_weight: float = 0.7,
+        diversity_bias: float = 0.15,
+    ) -> None:
+        if not 0.0 <= similarity_weight <= 1.0:
+            raise ValueError("similarity_weight must be between 0 and 1")
+        if diversity_bias < 0.0:
+            raise ValueError("diversity_bias must be non-negative")
         self.coverage_fn = coverage_fn or default_coverage
+        self.similarity_weight = similarity_weight
+        self.diversity_bias = diversity_bias
 
     def rerank(self, candidates: Sequence[Tuple[Document, float]], top_k: int = 5) -> List[Tuple[Document, float]]:
-        reranked = []
-        for doc, score in candidates:
-            coverage_score = self.coverage_fn(doc)
-            reranked.append((doc, score + coverage_score))
-        reranked.sort(key=lambda item: item[1], reverse=True)
-        return reranked[:top_k]
+        if top_k <= 0:
+            return []
+        if not candidates:
+            return []
+        coverage_scores: Dict[str, float] = {}
+        for doc, _ in candidates:
+            coverage_scores[doc.doc_id] = max(self.coverage_fn(doc), 0.0)
+        max_coverage = max(coverage_scores.values(), default=1.0) or 1.0
+        base_scores: List[Tuple[Document, float]] = []
+        for doc, similarity in candidates:
+            coverage_norm = coverage_scores[doc.doc_id] / max_coverage
+            score = self.similarity_weight * float(similarity) + (1 - self.similarity_weight) * coverage_norm
+            base_scores.append((doc, score))
+        selected: List[Tuple[Document, float]] = []
+        usage_counts: Dict[str, int] = defaultdict(int)
+        remaining = base_scores.copy()
+        while remaining and len(selected) < top_k:
+            best_index = -1
+            best_adjusted = float("-inf")
+            for idx, (doc, score) in enumerate(remaining):
+                group_id = doc.metadata.get("document_id", doc.metadata.get("source", doc.doc_id))
+                penalty = self.diversity_bias * usage_counts[group_id]
+                bonus = self.diversity_bias if usage_counts[group_id] == 0 else 0.0
+                adjusted_score = score + bonus - penalty
+                if adjusted_score > best_adjusted:
+                    best_adjusted = adjusted_score
+                    best_index = idx
+            if best_index == -1:
+                break
+            doc, _ = remaining.pop(best_index)
+            group_id = doc.metadata.get("document_id", doc.metadata.get("source", doc.doc_id))
+            usage_counts[group_id] += 1
+            selected.append((doc, best_adjusted))
+        return selected
+
+
+class CoverageReranker(CoverageAwareReranker):
+    """Backward compatible alias for the previous class name."""
+
+
+__all__ = ["CoverageAwareReranker", "CoverageReranker", "default_coverage"]

--- a/retrieval/__init__.py
+++ b/retrieval/__init__.py
@@ -1,0 +1,25 @@
+"""Retrieval strategies used across the chatbot stack."""
+from __future__ import annotations
+
+from typing import Protocol, Sequence, Tuple
+
+from data_ingestion.loader import Document
+
+
+class RetrieverProtocol(Protocol):
+    """Protocol for retrievers returning scored documents."""
+
+    def search(self, query: str, k: int = 5) -> Sequence[Tuple[Document, float]]:
+        """Return the ``k`` most relevant documents for ``query``."""
+
+
+from .bm25 import BM25Retriever
+from .dense import DenseRetriever
+from .prf import DualStagePRFRetriever
+
+__all__ = [
+    "RetrieverProtocol",
+    "BM25Retriever",
+    "DenseRetriever",
+    "DualStagePRFRetriever",
+]

--- a/retrieval/dense.py
+++ b/retrieval/dense.py
@@ -1,0 +1,27 @@
+"""Dense retriever backed by :class:`~indexing.vector_store.FaissVectorStore`."""
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from data_ingestion.loader import Document
+from indexing.vector_store import FaissVectorStore
+
+
+class DenseRetriever:
+    """Adapter exposing the vector store through the retriever protocol."""
+
+    def __init__(self, vector_store: FaissVectorStore) -> None:
+        self.vector_store = vector_store
+
+    def build_if_required(self, documents: Iterable[Document]) -> None:
+        """Ensure the underlying store is initialised with ``documents``."""
+
+        if getattr(self.vector_store, "id_to_doc", None):  # store already built
+            return
+        self.vector_store.build(list(documents))
+
+    def search(self, query: str, k: int = 5) -> List[Tuple[Document, float]]:
+        return list(self.vector_store.search(query, k=k))
+
+
+__all__ = ["DenseRetriever"]

--- a/retrieval/prf.py
+++ b/retrieval/prf.py
@@ -1,0 +1,127 @@
+"""Dual-stage pseudo relevance feedback retriever."""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Dict, List, Sequence, Tuple
+
+from data_ingestion.loader import Document
+
+from . import RetrieverProtocol
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "he",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "will",
+    "with",
+}
+_TOKEN_PATTERN = re.compile(r"\b\w+\b")
+
+
+class DualStagePRFRetriever:
+    """Augment a base retriever with pseudo relevance feedback."""
+
+    def __init__(
+        self,
+        base_retriever: RetrieverProtocol,
+        *,
+        feedback_depth: int = 3,
+        expansion_terms: int = 10,
+        re_rank_strategy: str = "sum",
+        feedback_weight: float = 0.6,
+    ) -> None:
+        if feedback_depth <= 0:
+            raise ValueError("feedback_depth must be positive")
+        if expansion_terms <= 0:
+            raise ValueError("expansion_terms must be positive")
+        if not 0.0 <= feedback_weight <= 1.0:
+            raise ValueError("feedback_weight must be between 0 and 1")
+        strategy = re_rank_strategy.lower()
+        if strategy not in {"sum", "max", "second"}:
+            raise ValueError("re_rank_strategy must be one of 'sum', 'max', or 'second'")
+        self.base_retriever = base_retriever
+        self.feedback_depth = feedback_depth
+        self.expansion_terms = expansion_terms
+        self.re_rank_strategy = strategy
+        self.feedback_weight = feedback_weight
+
+    def search(self, query: str, k: int = 5) -> List[Tuple[Document, float]]:
+        if not query:
+            return []
+        first_stage = list(self.base_retriever.search(query, k=max(k, self.feedback_depth)))
+        if not first_stage:
+            return []
+        feedback_docs = [doc for doc, _ in first_stage[: self.feedback_depth]]
+        expansion = self._build_feedback_query(feedback_docs)
+        if not expansion:
+            return first_stage[:k]
+        expanded_query = f"{query} {expansion}".strip()
+        second_stage = list(self.base_retriever.search(expanded_query, k=k))
+        combined = self._combine_results(first_stage, second_stage)
+        combined.sort(key=lambda item: item[1], reverse=True)
+        return combined[:k]
+
+    def _build_feedback_query(self, documents: Sequence[Document]) -> str:
+        tokens: List[str] = []
+        for document in documents:
+            tokens.extend(_TOKEN_PATTERN.findall(document.content.lower()))
+        filtered = [token for token in tokens if len(token) > 2 and token not in _STOPWORDS]
+        if not filtered:
+            return ""
+        most_common = [term for term, _ in Counter(filtered).most_common(self.expansion_terms)]
+        return " ".join(dict.fromkeys(most_common))
+
+    def _combine_results(
+        self,
+        first_stage: Sequence[Tuple[Document, float]],
+        second_stage: Sequence[Tuple[Document, float]],
+    ) -> List[Tuple[Document, float]]:
+        lookup: Dict[str, Document] = {}
+        first_scores: Dict[str, float] = {}
+        for doc, score in first_stage:
+            lookup[doc.doc_id] = doc
+            first_scores[doc.doc_id] = float(score)
+        second_scores: Dict[str, float] = {}
+        for doc, score in second_stage:
+            lookup[doc.doc_id] = doc
+            second_scores[doc.doc_id] = float(score)
+        combined: List[Tuple[Document, float]] = []
+        for doc_id, document in lookup.items():
+            base_score = first_scores.get(doc_id)
+            feedback_score = second_scores.get(doc_id)
+            combined_score = self._combine_scores(base_score, feedback_score)
+            combined.append((document, combined_score))
+        return combined
+
+    def _combine_scores(self, base: float | None, feedback: float | None) -> float:
+        if self.re_rank_strategy == "second":
+            return feedback if feedback is not None else (base or 0.0)
+        if self.re_rank_strategy == "max":
+            return max(base or 0.0, feedback or 0.0)
+        base_score = base or 0.0
+        feedback_score = feedback or 0.0
+        return (1 - self.feedback_weight) * base_score + self.feedback_weight * feedback_score
+
+
+__all__ = ["DualStagePRFRetriever"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
-from data_ingestion.loader import DocumentLoader
+from data_ingestion.loader import Document, DocumentLoader
 from generation.dummy import EchoGenerator
 from indexing.embedder import get_default_embedder, HashingEmbedder
 from indexing.index import HybridIndex, VectorIndex
 from pipelines.chatbot import RAGPipeline
+from retrieval import BM25Retriever, DualStagePRFRetriever
+from reranking.coverage import CoverageAwareReranker
 
 
 def test_end_to_end_query(tmp_path: Path) -> None:
@@ -45,3 +47,21 @@ def test_loader_and_index_integration(tmp_path: Path) -> None:
     results = index.query("rapid development", top_k=2)
     assert results
     assert any("python" in result.document.content.lower() for result in results)
+
+
+def test_retrieval_reranking_pipeline() -> None:
+    documents = [
+        Document(doc_id="a::1", content="Python supports async programming", metadata={"document_id": "a"}),
+        Document(doc_id="a::2", content="Asyncio provides event loops", metadata={"document_id": "a"}),
+        Document(doc_id="b::1", content="Rust offers fearless concurrency", metadata={"document_id": "b"}),
+    ]
+    base_retriever = BM25Retriever(documents)
+    prf = DualStagePRFRetriever(base_retriever, feedback_depth=1, expansion_terms=5, feedback_weight=0.5)
+    candidates = prf.search("async concurrency", k=3)
+    assert len(candidates) == 3
+    reranker = CoverageAwareReranker(similarity_weight=0.6, diversity_bias=0.25)
+    reranked = reranker.rerank(candidates, top_k=2)
+    assert len(reranked) == 2
+    assert reranked[0][1] >= reranked[1][1]
+    # Ensure reranker promotes documents from different parents when available
+    assert reranked[0][0].metadata["document_id"] != reranked[1][0].metadata["document_id"]

--- a/tests/test_reranking.py
+++ b/tests/test_reranking.py
@@ -1,11 +1,24 @@
 from data_ingestion.loader import Document
-from reranking.coverage import CoverageReranker
+from reranking.coverage import CoverageAwareReranker
 
 
-def test_reranker_orders_by_coverage() -> None:
-    doc_short = Document(doc_id="1", content="short text")
-    doc_long = Document(doc_id="2", content="long text " * 10)
-    candidates = [(doc_short, 0.5), (doc_long, 0.4)]
-    reranker = CoverageReranker()
+def test_reranker_balances_similarity_and_coverage() -> None:
+    doc_short = Document(doc_id="1", content="short text", metadata={"document_id": "A"})
+    doc_long = Document(doc_id="2", content="long text " * 10, metadata={"document_id": "B"})
+    candidates = [(doc_short, 0.9), (doc_long, 0.4)]
+    reranker = CoverageAwareReranker(similarity_weight=0.8)
     reranked = reranker.rerank(candidates, top_k=2)
-    assert reranked[0][0].doc_id == "2"
+    assert reranked[0][0].doc_id == "1"
+    assert reranked[1][0].doc_id == "2"
+
+
+def test_reranker_promotes_diverse_sources() -> None:
+    doc_a1 = Document(doc_id="1", content="topic A first", metadata={"document_id": "A"})
+    doc_a2 = Document(doc_id="2", content="topic A second", metadata={"document_id": "A"})
+    doc_b = Document(doc_id="3", content="topic B", metadata={"document_id": "B"})
+    candidates = [(doc_a1, 0.8), (doc_a2, 0.79), (doc_b, 0.6)]
+    reranker = CoverageAwareReranker(similarity_weight=0.8, diversity_bias=0.3)
+    reranked = reranker.rerank(candidates, top_k=3)
+    assert reranked[0][0].doc_id == "1"
+    # Ensure the second document provides coverage from a different source
+    assert reranked[1][0].metadata["document_id"] == "B"

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,18 +1,47 @@
+import pytest
+
 from data_ingestion.loader import Document
 from indexing.embedder import HashingEmbedder
 from indexing.vector_store import FaissVectorStore
-from retrieval.hybrid import HybridRetriever
+from retrieval import BM25Retriever, DenseRetriever, DualStagePRFRetriever
 
 
-def test_hybrid_retriever_returns_results() -> None:
-    docs = [
-        Document(doc_id="1", content="Python programming language"),
-        Document(doc_id="2", content="Data science with statistics"),
+@pytest.fixture
+def sample_documents() -> list[Document]:
+    return [
+        Document(doc_id="1", content="Space shuttles use rockets for orbital missions"),
+        Document(doc_id="2", content="Mars missions require precise orbital mechanics"),
+        Document(doc_id="3", content="Rocket propulsion relies on liquid fuel"),
     ]
-    embedder = HashingEmbedder()
-    store = FaissVectorStore(embedder=embedder, use_faiss=False)
-    store.build(docs)
-    retriever = HybridRetriever(docs, store)
-    results = retriever.search("Python", k=2)
+
+
+def test_bm25_retriever_ranks_relevant_document(sample_documents: list[Document]) -> None:
+    retriever = BM25Retriever(sample_documents)
+    results = retriever.search("orbital missions", k=2)
     assert results
-    assert any(doc.doc_id == "1" for doc, _ in results)
+    assert results[0][0].doc_id in {"1", "2"}
+
+
+def test_dense_retriever_returns_results(sample_documents: list[Document]) -> None:
+    embedder = HashingEmbedder(dim=64)
+    store = FaissVectorStore(embedder=embedder, use_faiss=False)
+    store.build(sample_documents)
+    retriever = DenseRetriever(store)
+    results = retriever.search("rocket fuel", k=2)
+    assert results
+    assert any(doc.doc_id == "3" for doc, _ in results)
+
+
+def test_dual_stage_prf_expands_query(sample_documents: list[Document]) -> None:
+    base_retriever = BM25Retriever(sample_documents)
+    prf_retriever = DualStagePRFRetriever(
+        base_retriever,
+        feedback_depth=1,
+        expansion_terms=5,
+        re_rank_strategy="sum",
+        feedback_weight=0.7,
+    )
+    initial_results = base_retriever.search("space mission", k=2)
+    assert all(doc.doc_id != "3" for doc, _ in initial_results)
+    prf_results = prf_retriever.search("space mission", k=3)
+    assert any(doc.doc_id == "3" for doc, _ in prf_results)


### PR DESCRIPTION
## Summary
- add dense retriever adapter and dual-stage pseudo relevance feedback retriever with configurable behaviour
- upgrade coverage reranker to a diversity-aware scoring module and provide backwards compatible alias
- expand unit and integration tests to cover new retrieval, reranking, and combined pipeline flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68deaf27cdc08322839888db632a2cdd