### PR TITLE
Add deployment scripts, monitoring, and scaling documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,22 @@ assert "ci@example.com" not in json.dumps(failures)
 assert "Neptune" not in json.dumps(failures)
 markdown = (run_dir / "failures.md").read_text(encoding="utf-8")
 assert "ci@example.com" not in markdown
-assert "Neptune" not in markdown
-PY
+          assert "Neptune" not in markdown
+          PY
+
+  deployment-check:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Smoke test deployment scripts
+        run: make deploy-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: run server ui test tiny-bench report lint fmt analyze
+.PHONY: run server ui test tiny-bench report lint fmt analyze run-local run-org deploy-check load-test
 
 run:
-	python scripts/run_demo.py
+        python scripts/run_demo.py
+
+run-local:
+        python deploy/local_run.py --config deploy/configs/local.yaml --index-type bm25
+
+run-org:
+        python deploy/org_run.py --config deploy/configs/org.yaml --index-type bm25
 
 server:
 	uvicorn ui.server:app --host 0.0.0.0 --port 8000
@@ -19,13 +25,103 @@ report:
 	ragx-report --run-dir $$(ls -td runs/* | head -1) --format md --title "RAGX Benchmark"
 
 analyze:
-	ragx-analyze --run-dir $$(ls -td runs/* | head -1) --redact
+        ragx-analyze --run-dir $$(ls -td runs/* | head -1) --redact
 
 lint:
-	ruff check .
-	mypy .
-	flake8 || true
+        ruff check .
+        mypy .
+        flake8 || true
 
 fmt:
-	black .
-	isort .
+        black .
+        isort .
+
+deploy-check:
+        python - <<'PY'
+import subprocess
+import sys
+import tempfile
+import time
+import requests
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent
+
+def wait_for(url: str, timeout: float = 20.0) -> None:
+    start = time.perf_counter()
+    while time.perf_counter() - start < timeout:
+        try:
+            response = requests.get(url, timeout=2)
+            if response.status_code == 200:
+                return
+        except requests.RequestException:
+            time.sleep(0.5)
+    raise RuntimeError(f"Timed out waiting for {url}")
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp_path = Path(tmp)
+    local = subprocess.Popen(
+        [
+            sys.executable,
+            "deploy/local_run.py",
+            "--config",
+            "deploy/configs/local.yaml",
+            "--index-type",
+            "bm25",
+            "--port-api",
+            "8123",
+            "--port-ui",
+            "8623",
+            "--run-duration",
+            "8",
+            "--no-ui",
+            "--index-path",
+            str(tmp_path / "local-index"),
+        ],
+        cwd=project_root,
+    )
+    wait_for("http://localhost:8123/healthz")
+    resp = requests.post("http://localhost:8123/chat", json={"query": "hi", "top_k": 1}, timeout=10)
+    resp.raise_for_status()
+    local.wait()
+
+    org = subprocess.Popen(
+        [
+            sys.executable,
+            "deploy/org_run.py",
+            "--config",
+            "deploy/configs/org.yaml",
+            "--index-type",
+            "bm25",
+            "--port-api",
+            "9123",
+            "--port-ui",
+            "9623",
+            "--run-duration",
+            "8",
+            "--no-ui",
+            "--index-path",
+            str(tmp_path / "org-index"),
+            "--log-dir",
+            str(tmp_path / "logs"),
+            "--api-key",
+            "ci-key",
+        ],
+        cwd=project_root,
+    )
+    wait_for("http://localhost:9123/healthz")
+    headers = {"X-API-Key": "ci-key"}
+    resp = requests.post("http://localhost:9123/chat", json={"query": "hello", "top_k": 1}, headers=headers, timeout=10)
+    resp.raise_for_status()
+    metrics = requests.get("http://localhost:9123/metrics", headers=headers, timeout=10)
+    metrics.raise_for_status()
+    org.wait()
+PY
+
+BASE_URL ?= http://localhost:8000
+REQUESTS ?= 20
+CONCURRENCY ?= 4
+TOP_K ?= 4
+
+load-test:
+        python deploy/scripts/benchmark_load.py --base-url $(BASE_URL) --requests $(REQUESTS) --concurrency $(CONCURRENCY) --top-k $(TOP_K)

--- a/README.md
+++ b/README.md
@@ -92,15 +92,13 @@ streamlit run ui/streamlit_app.py
 
 The UI provides a chat-style interface, a retrieval panel with highlighted matches, and a metrics sidebar summarising latency, reranker impact, and citation details. The app communicates with the FastAPI server, so ensure it is running locally or point the sidebar configuration to a deployed instance.
 
-### One-command Demo
+### Deployment & Scaling
 
-Use the bundled runner to start both services together:
+- **Local developer sandbox:** `make run-local` loads the sample dataset, starts the FastAPI API on `http://localhost:8000`, and launches the Streamlit UI on `http://localhost:8501`.
+- **Small organisation mode:** `make run-org` reuses a shared NAS index, enables API keys + rate limiting, and exposes `/metrics` for lightweight monitoring.
+- Detailed instructions, diagrams, and troubleshooting tips live in [`docs/DEPLOYMENT_GUIDE.md`](docs/DEPLOYMENT_GUIDE.md).
 
-```bash
-make run
-```
-
-Both interfaces default to lightweight embeddings and the pure-Python vector store so they run without optional dependencies. Set `use_faiss=True` when constructing `RAGPipeline` to leverage FAISS if it is installed.
+Both deployment paths default to the lightweight Python indexer so they run without optional dependencies. Set `--index-type faiss` (or update the config) when FAISS is installed to accelerate similarity search.
 
 ## Configuration
 

--- a/configs/loader.py
+++ b/configs/loader.py
@@ -1,0 +1,132 @@
+"""Helpers for loading and validating deployment configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+
+class RateLimitConfig(BaseModel):
+    """Basic token-bucket configuration for the API server."""
+
+    requests_per_minute: int = Field(..., gt=0, description="Allowed requests per minute")
+    burst: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Maximum burst capacity. Defaults to the same value as ``requests_per_minute`` "
+            "when not provided."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_burst(self) -> "RateLimitConfig":  # pragma: no cover - trivial
+        if self.burst is None:
+            object.__setattr__(self, "burst", self.requests_per_minute)
+        return self
+
+
+class LoggingConfig(BaseModel):
+    """Location for structured logs."""
+
+    directory: Path
+
+    @model_validator(mode="after")
+    def _ensure_directory(self) -> "LoggingConfig":
+        self.directory = self.directory.expanduser().resolve()
+        return self
+
+
+class DeploymentConfig(BaseModel):
+    """Schema covering both local and small-organisation deployments."""
+
+    mode: str = Field(description="Deployment mode (local or org)")
+    dataset: Path = Field(description="Path to the dataset to ingest")
+    index_type: str = Field(description="Index backend to use (faiss, bm25, hybrid)")
+    api_port: int = Field(gt=0, lt=65536)
+    ui_port: int = Field(gt=0, lt=65536)
+    reranker: str | None = None
+    index_path: Optional[Path] = None
+    workers: int = Field(default=1, gt=0)
+    enable_redaction: bool = Field(default=False)
+    logging: Optional[LoggingConfig] = None
+    rate_limit: Optional[RateLimitConfig] = None
+    api_keys: Optional[list[str]] = Field(default=None)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @model_validator(mode="after")
+    def _post_init(self) -> "DeploymentConfig":
+        mode = self.mode.lower()
+        if mode not in {"local", "org"}:
+            raise ValueError("mode must be 'local' or 'org'")
+        object.__setattr__(self, "mode", mode)
+        self.dataset = self.dataset.expanduser().resolve()
+        if self.index_path is not None:
+            self.index_path = self.index_path.expanduser().resolve()
+        if self.api_keys:
+            if len({key.strip() for key in self.api_keys if key.strip()}) == 0:
+                raise ValueError("api_keys must contain at least one non-empty key")
+            self.api_keys = [key.strip() for key in self.api_keys if key.strip()]
+        if self.mode == "org" and not self.index_path:
+            raise ValueError("Organisation deployments require an index_path")
+        if self.mode == "org" and not self.logging:
+            raise ValueError("Organisation deployments require a logging directory")
+        return self
+
+
+DEFAULT_VALUES: Dict[str, Any] = {
+    "mode": "local",
+    "dataset": "data/sample_docs",
+    "index_type": "faiss",
+    "api_port": 8000,
+    "ui_port": 8501,
+    "reranker": "coverage",
+    "workers": 1,
+}
+
+
+def _deep_merge(base: MutableMapping[str, Any], updates: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    for key, value in updates.items():
+        if (
+            key in base
+            and isinstance(base[key], MutableMapping)
+            and isinstance(value, Mapping)
+        ):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(path: str | Path, overrides: Optional[Mapping[str, Any]] = None) -> DeploymentConfig:
+    """Load a deployment config, merging defaults, file contents, and overrides."""
+
+    config_path = Path(path).expanduser()
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    raw = DEFAULT_VALUES.copy()
+    with config_path.open("r", encoding="utf-8") as handle:
+        file_values = yaml.safe_load(handle) or {}
+    if not isinstance(file_values, Mapping):
+        raise TypeError("Config file must contain a mapping at the top level")
+    merged: Dict[str, Any] = _deep_merge(raw, dict(file_values))  # type: ignore[arg-type]
+    if overrides:
+        merged = _deep_merge(merged, dict(overrides))
+    try:
+        return DeploymentConfig(**merged)
+    except ValidationError as exc:  # pragma: no cover - handled via tests, defensive
+        raise ValueError(f"Invalid deployment config: {exc}") from exc
+
+
+__all__ = [
+    "DeploymentConfig",
+    "LoggingConfig",
+    "RateLimitConfig",
+    "load_config",
+]
+

--- a/data/organization_corpus/mission.txt
+++ b/data/organization_corpus/mission.txt
@@ -1,0 +1,2 @@
+The organization corpus contains shared knowledge about the lab mission.
+We collaborate on retrieval augmented generation systems and deploy them securely.

--- a/deploy/configs/local.yaml
+++ b/deploy/configs/local.yaml
@@ -1,0 +1,7 @@
+mode: local
+dataset: data/sample_docs
+index_type: faiss
+api_port: 8000
+ui_port: 8501
+reranker: coverage
+index_path: ~/.ragx/index

--- a/deploy/configs/org.yaml
+++ b/deploy/configs/org.yaml
@@ -1,0 +1,16 @@
+mode: org
+dataset: data/organization_corpus
+index_path: /shared/ragx/index/
+workers: 4
+api_port: 9000
+ui_port: 8501
+index_type: faiss
+reranker: coverage
+enable_redaction: true
+logging:
+  directory: /shared/ragx/logs/
+rate_limit:
+  requests_per_minute: 120
+  burst: 180
+api_keys:
+  - team-secret-key

--- a/deploy/local_run.py
+++ b/deploy/local_run.py
@@ -1,0 +1,30 @@
+"""One-click launcher for local RAG deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from .runtime import load_runtime_config, parse_common_args, ServiceRuntime
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "configs" / "local.yaml"
+
+
+def main(argv: list[str] | None = None) -> None:
+    options = parse_common_args(argv or sys.argv[1:], str(DEFAULT_CONFIG))
+    config = load_runtime_config(options)
+    runtime = ServiceRuntime(config, include_ui=options.include_ui)
+    print("[ragx] Starting local deployment")
+    print(f"[ragx] Dataset: {config.dataset}")
+    if config.index_path:
+        print(f"[ragx] Index directory: {config.index_path}")
+    print(f"[ragx] API:    http://localhost:{config.api_port}")
+    if options.include_ui:
+        print(f"[ragx] UI:     http://localhost:{config.ui_port}")
+    asyncio.run(runtime.run(duration=options.run_duration))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/deploy/org_run.py
+++ b/deploy/org_run.py
@@ -1,0 +1,42 @@
+"""Launcher tailored for small-organisation deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from .runtime import load_runtime_config, parse_common_args, ServiceRuntime
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "configs" / "org.yaml"
+
+
+def main(argv: list[str] | None = None) -> None:
+    options = parse_common_args(argv or sys.argv[1:], str(DEFAULT_CONFIG))
+    config = load_runtime_config(options)
+    runtime = ServiceRuntime(config, include_ui=options.include_ui)
+
+    print("[ragx] Starting organisation deployment")
+    print(f"[ragx] Dataset: {config.dataset}")
+    if config.index_path:
+        print(f"[ragx] Shared index: {config.index_path}")
+    if config.logging:
+        print(f"[ragx] Logs directory: {config.logging.directory}")
+    print(f"[ragx] API workers: {config.workers}")
+    if config.rate_limit:
+        print(
+            f"[ragx] Rate limit: {config.rate_limit.requests_per_minute}/min"
+            f" burst={config.rate_limit.burst}"
+        )
+    if config.api_keys:
+        print(f"[ragx] API keys configured: {len(config.api_keys)}")
+    print(f"[ragx] API endpoint: http://0.0.0.0:{config.api_port}")
+    if options.include_ui:
+        print(f"[ragx] UI endpoint: http://0.0.0.0:{config.ui_port}")
+
+    asyncio.run(runtime.run(duration=options.run_duration))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/deploy/runtime.py
+++ b/deploy/runtime.py
@@ -1,0 +1,202 @@
+"""Shared helpers for deployment scripts."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import signal
+import sys
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import uvicorn
+
+from analysis.redaction import RedactionSettings, TextRedactor
+from configs.loader import DeploymentConfig, load_config
+from monitoring import MetricsStore, configure_logging
+from ui.server import create_app
+
+
+@dataclass(slots=True)
+class RuntimeOptions:
+    config_path: Path
+    overrides: dict[str, object]
+    include_ui: bool = True
+    run_duration: float | None = None
+
+
+class ServiceRuntime:
+    """Launch and manage API/UI services for deployments."""
+
+    def __init__(self, config: DeploymentConfig, include_ui: bool = True) -> None:
+        self.config = config
+        self.include_ui = include_ui
+        self.metrics = MetricsStore()
+        self.logger = configure_logging(
+            config.logging.directory if config.logging else None
+        )
+        self.redactor = (
+            TextRedactor(RedactionSettings()) if config.enable_redaction else None
+        )
+        self._api_server: uvicorn.Server | None = None
+        self._ui_process: asyncio.subprocess.Process | None = None
+
+    async def run(self, duration: float | None = None) -> None:
+        self._prepare_filesystem()
+        app = create_app(
+            config=self.config,
+            metrics_store=self.metrics,
+            logger=self.logger,
+            redactor=self.redactor,
+        )
+        api_task = asyncio.create_task(self._serve_api(app))
+        tasks = [api_task]
+        if self.include_ui:
+            tasks.append(asyncio.create_task(self._launch_streamlit()))
+
+        if duration is not None:
+            async def _auto_shutdown() -> None:
+                await asyncio.sleep(duration)
+                await self.shutdown()
+
+            tasks.append(asyncio.create_task(_auto_shutdown()))
+
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(
+                    sig, lambda s=sig: asyncio.create_task(self.shutdown())
+                )
+            except NotImplementedError:  # pragma: no cover - Windows compatibility
+                pass
+
+        await asyncio.gather(*tasks)
+
+    async def shutdown(self) -> None:
+        if self._api_server is not None:
+            self._api_server.should_exit = True
+        if self._ui_process is not None and self._ui_process.returncode is None:
+            with suppress(ProcessLookupError):
+                self._ui_process.terminate()
+                await asyncio.wait_for(self._ui_process.wait(), timeout=5)
+
+    async def _serve_api(self, app) -> None:
+        config = uvicorn.Config(
+            app,
+            host="0.0.0.0",
+            port=self.config.api_port,
+            log_level="info",
+            workers=self.config.workers,
+        )
+        server = uvicorn.Server(config)
+        self._api_server = server
+        self.logger.info(
+            "api_starting",
+            extra={
+                "extra_data": {
+                    "port": self.config.api_port,
+                    "workers": self.config.workers,
+                }
+            },
+        )
+        await server.serve()
+
+    async def _launch_streamlit(self) -> None:
+        env = {**os.environ, "RAG_API_URL": f"http://localhost:{self.config.api_port}"}
+        command = [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            str(Path(__file__).resolve().parent.parent / "ui" / "streamlit_app.py"),
+            "--server.port",
+            str(self.config.ui_port),
+        ]
+        self.logger.info(
+            "ui_starting",
+            extra={
+                "extra_data": {
+                    "port": self.config.ui_port,
+                    "api_url": env["RAG_API_URL"],
+                }
+            },
+        )
+        self._ui_process = await asyncio.create_subprocess_exec(*command, env=env)
+        await self._ui_process.wait()
+
+    def _prepare_filesystem(self) -> None:
+        if self.config.index_path:
+            self.config.index_path.mkdir(parents=True, exist_ok=True)
+        if self.config.logging:
+            self.config.logging.directory.mkdir(parents=True, exist_ok=True)
+
+
+def parse_common_args(argv: Iterable[str], default_config: str) -> RuntimeOptions:
+    parser = argparse.ArgumentParser(description="RAG deployment runner")
+    parser.add_argument("--config", default=default_config, help="Path to YAML config")
+    parser.add_argument("--dataset", help="Override dataset path")
+    parser.add_argument("--index-type", help="Index backend override")
+    parser.add_argument("--reranker", help="Reranker override")
+    parser.add_argument("--port-api", type=int, help="API port override")
+    parser.add_argument("--port-ui", type=int, help="UI port override")
+    parser.add_argument("--workers", type=int, help="Number of API workers")
+    parser.add_argument("--index-path", help="Shared index directory")
+    parser.add_argument("--log-dir", help="Directory for structured logs")
+    parser.add_argument("--api-key", action="append", help="API keys allowed to access the API")
+    parser.add_argument(
+        "--rate-limit",
+        type=int,
+        help="Requests per minute allowed for each client",
+    )
+    parser.add_argument(
+        "--rate-burst",
+        type=int,
+        help="Burst capacity for rate limiting",
+    )
+    parser.add_argument("--no-ui", action="store_true", help="Disable Streamlit UI")
+    parser.add_argument(
+        "--run-duration",
+        type=float,
+        help="Automatically shutdown after N seconds (useful for tests)",
+    )
+    args = parser.parse_args(list(argv))
+    overrides: dict[str, object] = {}
+    if args.dataset:
+        overrides["dataset"] = args.dataset
+    if args.index_type:
+        overrides["index_type"] = args.index_type
+    if args.reranker:
+        overrides["reranker"] = args.reranker
+    if args.port_api:
+        overrides["api_port"] = args.port_api
+    if args.port_ui:
+        overrides["ui_port"] = args.port_ui
+    if args.workers:
+        overrides["workers"] = args.workers
+    if args.index_path:
+        overrides["index_path"] = args.index_path
+    if args.log_dir:
+        overrides["logging"] = {"directory": args.log_dir}
+    if args.api_key:
+        overrides["api_keys"] = args.api_key
+    if args.rate_limit:
+        overrides["rate_limit"] = {"requests_per_minute": args.rate_limit}
+    if args.rate_burst:
+        overrides.setdefault("rate_limit", {})["burst"] = args.rate_burst
+    return RuntimeOptions(
+        config_path=Path(args.config),
+        overrides=overrides,
+        include_ui=not args.no_ui,
+        run_duration=args.run_duration,
+    )
+
+
+def load_runtime_config(options: RuntimeOptions) -> DeploymentConfig:
+    return load_config(options.config_path, options.overrides)
+
+
+__all__ = ["RuntimeOptions", "ServiceRuntime", "parse_common_args", "load_runtime_config"]
+

--- a/deploy/scripts/benchmark_load.py
+++ b/deploy/scripts/benchmark_load.py
@@ -1,0 +1,104 @@
+"""Lightweight load test for the RAG API."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import math
+import statistics
+import time
+from typing import List
+
+import httpx
+
+
+def percentile(latencies: List[float], pct: float) -> float:
+    if not latencies:
+        return 0.0
+    index = max(0, min(len(latencies) - 1, math.ceil(pct / 100.0 * len(latencies)) - 1))
+    return latencies[index]
+
+
+async def _worker(
+    client: httpx.AsyncClient,
+    query: str,
+    top_k: int,
+    request_count: int,
+    delay: float,
+    latencies: List[float],
+) -> None:
+    for _ in range(request_count):
+        start = time.perf_counter()
+        response = await client.post(
+            "/chat",
+            json={"query": query, "top_k": top_k},
+        )
+        response.raise_for_status()
+        elapsed = (time.perf_counter() - start) * 1000
+        latencies.append(elapsed)
+        if delay:
+            await asyncio.sleep(delay)
+
+
+async def run_load_test(
+    base_url: str,
+    total_requests: int,
+    concurrency: int,
+    query: str,
+    top_k: int,
+    rps: float | None = None,
+) -> dict[str, float]:
+    per_worker = max(1, total_requests // concurrency)
+    delay = 0.0
+    if rps and rps > 0:
+        delay = max(0.0, concurrency / rps - 1e-6)
+    latencies: List[float] = []
+    async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+        tasks = [
+            asyncio.create_task(
+                _worker(client, query, top_k, per_worker, delay, latencies)
+            )
+            for _ in range(concurrency)
+        ]
+        await asyncio.gather(*tasks)
+    latencies.sort()
+    return {
+        "requests": len(latencies),
+        "avg_ms": statistics.fmean(latencies) if latencies else 0.0,
+        "p50_ms": percentile(latencies, 50),
+        "p90_ms": percentile(latencies, 90),
+        "p99_ms": percentile(latencies, 99),
+    }
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Benchmark the RAG API")
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--requests", type=int, default=20)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--query", default="What is the project mission?")
+    parser.add_argument("--top-k", type=int, default=4)
+    parser.add_argument("--rps", type=float, help="Target requests per second")
+    args = parser.parse_args(argv)
+
+    results = asyncio.run(
+        run_load_test(
+            base_url=args.base_url,
+            total_requests=args.requests,
+            concurrency=args.concurrency,
+            query=args.query,
+            top_k=args.top_k,
+            rps=args.rps,
+        )
+    )
+    print("Load test results:")
+    for key, value in results.items():
+        if key.endswith("ms"):
+            print(f"  {key}: {value:.2f} ms")
+        else:
+            print(f"  {key}: {value}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,168 @@
+# Deployment Guide
+
+This guide explains how to launch the Retrieval-Augmented Generation (RAG) stack
+locally and in a small-organisation setting. The tooling is entirely
+Python-driven – no containers required – and is optimised for reproducibility.
+
+## 1. Local Mode
+
+Local mode is intended for a single developer experimenting on a laptop with
+toy datasets.
+
+### Prerequisites
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Ensure the sample documents exist (`data/sample_docs`).
+
+### Quickstart
+
+```bash
+make run-local
+```
+
+The shortcut expands to:
+
+```bash
+python deploy/local_run.py --config deploy/configs/local.yaml --index-type bm25
+```
+
+Key behaviours:
+
+- Builds the index at `~/.ragx/index/` (can be overridden via CLI).
+- Starts the FastAPI service on `http://localhost:8000`.
+- Launches the Streamlit UI on `http://localhost:8501`.
+- Uses the lightweight Python-only indexer by default to minimise optional
+  dependencies.
+
+Once the services are running visit the UI, enter a question, and observe the
+retrieval diagnostics and answer references.
+
+### Local Architecture Overview
+
+```
++---------+        HTTP        +-----------+        In-memory         +------+
+| Browser |  <---------------- | Streamlit |  <--------------------> | RAG  |
++---------+                    +-----------+                         | Core |
+                                                                   +------+ 
+```
+
+## 2. Organisation Mode
+
+Organisation mode is optimised for a small lab or research team sharing an
+index on a network-attached storage (NAS) drive.
+
+### Shared Setup
+
+1. Mount the shared drive on each machine (e.g. `/shared/ragx/`).
+2. Copy or mount the corpus under `data/organization_corpus/`.
+3. Create log and index directories: `/shared/ragx/index/` and `/shared/ragx/logs/`.
+
+### Start the Services
+
+```bash
+make run-org
+```
+
+This resolves to:
+
+```bash
+python deploy/org_run.py --config deploy/configs/org.yaml --index-type bm25
+```
+
+Organisation-specific behaviour:
+
+- Shared index stored at `/shared/ragx/index/`.
+- Structured query logs emitted to `/shared/ragx/logs/` with anonymised IDs.
+- Multiple API workers (configurable) served through Uvicorn.
+- Optional API keys via `X-API-Key` header, plus token-bucket rate limiting.
+- Automatic redaction enabled to guard against accidental PII exposure.
+- Health and metrics endpoints (`/healthz`, `/metrics`) for lightweight monitoring.
+
+### Organisation Architecture Overview
+
+```
++---------+     +--------------+     +-------------------+     +-----------+
+| Users   | --> | Load Balancer| --> | FastAPI Workers   | --> | Shared    |
+| (Teams) |     |   (optional) |     | (uvicorn --workers)|     | Index NAS |
++---------+     +--------------+     +-------------------+     +-----------+
+                                            ^
+                                            |
+                                    +---------------+
+                                    | Streamlit UI  |
+                                    +---------------+
+```
+
+## 3. Scaling Strategies
+
+Even small teams benefit from planned scaling pathways:
+
+### Vertical Scaling
+
+- Upgrade to machines with additional RAM to cache larger indexes.
+- Prefer NVMe SSDs on the shared NAS for faster FAISS persistence.
+- Enable FAISS (`--index-type faiss`) when the dependency is installed.
+
+### Horizontal Scaling
+
+- Deploy the FastAPI server on 2–3 machines behind a simple round-robin load
+  balancer while sharing the same NAS index path.
+- Run `python deploy/org_run.py --workers 4` on each node to increase throughput.
+- Use the `/metrics` endpoint to track query latency and throughput per node.
+
+### Caching Layer (Optional)
+
+- Add Redis or SQLite as a query cache sitting in front of the API to store
+  recent results. The current design exposes hooks in the deployment scripts
+  (`ServiceRuntime`) for injecting additional middleware if desired.
+
+## 4. Monitoring & Health Checks
+
+- `/healthz` returns `{"status": "ok"}` once the pipeline is ready.
+- `/metrics` returns aggregated latency, throughput, and coverage stats.
+- Query logs are emitted as JSON lines inside the configured log directory.
+- JSON structured logs (`ragx.log`) rotate automatically.
+
+## 5. Troubleshooting
+
+| Issue | Resolution |
+|-------|------------|
+| Port already in use | Override ports via `--port-api` / `--port-ui`.
+| Shared drive missing | Update `index_path` and `logging.directory` to local paths or ensure the NAS is mounted.
+| Index too large for memory | Switch to FAISS with an ANN index, or increase RAM / use sharded indexes.
+| 401 responses in org mode | Ensure `X-API-Key` matches one of the configured API keys.
+| 429 responses | Increase `rate_limit.requests_per_minute` or add more workers.
+| UI cannot reach API | Confirm `RAG_API_URL` environment variable is set and accessible from Streamlit.
+
+## 6. Example Configurations
+
+- Local: `deploy/configs/local.yaml`
+- Organisation: `deploy/configs/org.yaml`
+
+Override settings on the CLI to avoid editing the files directly. Example:
+
+```bash
+python deploy/org_run.py --config deploy/configs/org.yaml \
+    --index-path /mnt/rag/index \
+    --log-dir /mnt/rag/logs \
+    --api-key team-alpha --api-key team-beta \
+    --rate-limit 200 --rate-burst 250
+```
+
+This launches the API with custom index/log directories and two API keys, while
+raising rate limits for power users.
+
+## 7. Load Testing
+
+Use the bundled benchmark script to run a quick smoke test:
+
+```bash
+make load-test BASE_URL=http://localhost:9000 REQUESTS=40 CONCURRENCY=8
+```
+
+Inspect the percentile latencies and compare across scaling experiments. The
+script uses HTTPX and respects the `/chat` endpoint contract.
+
+---
+
+For deeper automation and integration with CI/CD, see the updated workflow in
+`.github/workflows/ci.yml`, which exercises both local and organisation modes.

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,0 +1,7 @@
+"""Monitoring helpers for deployment scripts."""
+
+from .logging import configure_logging
+from .metrics import MetricsStore
+
+__all__ = ["configure_logging", "MetricsStore"]
+

--- a/monitoring/logging.py
+++ b/monitoring/logging.py
@@ -1,0 +1,48 @@
+"""Structured logging utilities for deployment."""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging import Logger
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class JsonFormatter(logging.Formatter):
+    """Emit log records as compact JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        payload: Dict[str, Any] = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.__dict__.get("extra_data"):
+            payload.update(record.__dict__["extra_data"])
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(log_dir: Optional[Path] = None) -> Logger:
+    """Configure structured logging and return the application logger."""
+
+    logger = logging.getLogger("ragx")
+    logger.setLevel(logging.INFO)
+    handler: logging.Handler
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "ragx.log"
+        handler = RotatingFileHandler(log_path, maxBytes=5_000_000, backupCount=5)
+    else:
+        handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logger.handlers = [handler]
+    logger.propagate = False
+    return logger
+
+
+__all__ = ["configure_logging", "JsonFormatter"]
+

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -1,0 +1,74 @@
+"""In-memory metrics store for the RAG services."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass(slots=True)
+class MetricsSnapshot:
+    uptime_seconds: float
+    queries_total: int
+    avg_latency_ms: float
+    throughput_per_minute: float
+    retrieval_hits: float
+    coverage_score: float
+
+
+@dataclass
+class MetricsStore:
+    """Track latency and retrieval metrics in memory."""
+
+    start_time: float = field(default_factory=time.perf_counter)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _total_latency_ms: float = 0.0
+    _query_count: int = 0
+    _retrieval_hits_sum: float = 0.0
+    _coverage_sum: float = 0.0
+
+    def record(
+        self,
+        latency_ms: float,
+        retrieval_hit_ratio: float,
+        coverage_score: float,
+    ) -> None:
+        with self._lock:
+            self._total_latency_ms += max(0.0, latency_ms)
+            self._retrieval_hits_sum += max(0.0, min(1.0, retrieval_hit_ratio))
+            self._coverage_sum += max(0.0, min(1.0, coverage_score))
+            self._query_count += 1
+
+    def snapshot(self) -> MetricsSnapshot:
+        with self._lock:
+            count = self._query_count
+            avg_latency = self._total_latency_ms / count if count else 0.0
+            avg_hits = self._retrieval_hits_sum / count if count else 0.0
+            avg_coverage = self._coverage_sum / count if count else 0.0
+        uptime = time.perf_counter() - self.start_time
+        throughput = (count / (uptime / 60.0)) if uptime > 0 else 0.0
+        return MetricsSnapshot(
+            uptime_seconds=uptime,
+            queries_total=count,
+            avg_latency_ms=avg_latency,
+            throughput_per_minute=throughput,
+            retrieval_hits=avg_hits,
+            coverage_score=avg_coverage,
+        )
+
+    def as_dict(self) -> Dict[str, float | int]:
+        snapshot = self.snapshot()
+        return {
+            "uptime_seconds": round(snapshot.uptime_seconds, 3),
+            "queries_total": snapshot.queries_total,
+            "avg_latency_ms": round(snapshot.avg_latency_ms, 3),
+            "throughput_per_minute": round(snapshot.throughput_per_minute, 3),
+            "retrieval_hits": round(snapshot.retrieval_hits, 3),
+            "coverage_score": round(snapshot.coverage_score, 3),
+        }
+
+
+__all__ = ["MetricsStore", "MetricsSnapshot"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,18 @@ version = "0.1.0"
 description = "Production-ready scaffold for a retrieval-augmented generation chatbot"
 authors = ["AI Engineer <ai@example.com>"]
 readme = "README.md"
-packages = [{ include = "data_ingestion" }, { include = "indexing" }, { include = "retrieval" }, { include = "reranking" }, { include = "generation" }, { include = "evaluation" }, { include = "pipelines" }, { include = "ui" }]
+packages = [
+    { include = "data_ingestion" },
+    { include = "indexing" },
+    { include = "retrieval" },
+    { include = "reranking" },
+    { include = "generation" },
+    { include = "evaluation" },
+    { include = "pipelines" },
+    { include = "ui" },
+    { include = "deploy" },
+    { include = "monitoring" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -23,6 +34,7 @@ nltk = "^3.8.1"
 rouge-score = "^0.1.2"
 pydantic = "^2.7.1"
 requests = "^2.32.3"
+httpx = "^0.27.0"
 PyYAML = "^6.0.1"
 typer = "^0.12.3"
 Jinja2 = "^3.1.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ rouge-score==0.1.2
 pydantic==2.7.1
 pytest==8.2.0
 requests==2.32.3
+httpx==0.27.0
 PyYAML==6.0.1
 typer==0.12.3
 Jinja2==3.1.4

--- a/tests/test_deploy_local.py
+++ b/tests/test_deploy_local.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from configs.loader import load_config
+from ui.server import create_app
+
+
+def test_local_config_overrides(tmp_path) -> None:
+    config = load_config(
+        Path("deploy/configs/local.yaml"),
+        {
+            "api_port": 8200,
+            "index_type": "bm25",
+            "index_path": str(tmp_path / "index"),
+        },
+    )
+    assert config.api_port == 8200
+    assert config.index_type == "bm25"
+    assert config.index_path == (tmp_path / "index").resolve()
+
+
+def test_local_app_health_endpoint(tmp_path) -> None:
+    config = load_config(
+        Path("deploy/configs/local.yaml"),
+        {
+            "index_type": "bm25",
+            "api_port": 8300,
+            "ui_port": 8700,
+            "index_path": str(tmp_path / "index"),
+        },
+    )
+    app = create_app(config=config)
+    with TestClient(app) as client:
+        health = client.get("/healthz").json()
+        assert health["status"] in {"ok", "starting"}
+        response = client.post("/query", json={"query": "test", "top_k": 2})
+        assert response.status_code == 200
+
+
+def test_org_config_validation(tmp_path) -> None:
+    config_path = tmp_path / "org.yaml"
+    config_path.write_text(
+        """
+mode: org
+dataset: data/sample_docs
+index_type: bm25
+api_port: 9000
+ui_port: 9500
+        """.strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_config(config_path)
+

--- a/tests/test_deploy_org.py
+++ b/tests/test_deploy_org.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from configs.loader import DeploymentConfig
+from ui.server import create_app
+
+
+def test_org_mode_enforces_api_key_and_redaction(tmp_path) -> None:
+    config = DeploymentConfig(
+        mode="org",
+        dataset=Path("data/organization_corpus"),
+        index_type="bm25",
+        api_port=9000,
+        ui_port=9500,
+        reranker="coverage",
+        index_path=tmp_path / "index",
+        workers=1,
+        enable_redaction=True,
+        logging={"directory": tmp_path / "logs"},
+        api_keys=["secret"],
+        rate_limit={"requests_per_minute": 1, "burst": 1},
+    )
+    app = create_app(config=config)
+    with TestClient(app) as client:
+        unauth = client.post("/chat", json={"query": "hello", "top_k": 2})
+        assert unauth.status_code == 401
+        headers = {"X-API-Key": "secret"}
+        first = client.post(
+            "/chat",
+            json={"query": "Contact me at example@org.com", "top_k": 2},
+            headers=headers,
+        )
+        assert first.status_code == 200
+        assert "[REDACTED_EMAIL]" in first.json()["answer"]
+        second = client.post(
+            "/chat",
+            json={"query": "Contact me at example@org.com", "top_k": 2},
+            headers=headers,
+        )
+        assert second.status_code == 429
+

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from configs.loader import DeploymentConfig
+from monitoring.metrics import MetricsStore
+from ui.server import create_app
+
+
+def test_metrics_store_records_basic_stats() -> None:
+    store = MetricsStore()
+    store.record(latency_ms=100, retrieval_hit_ratio=0.5, coverage_score=0.7)
+    store.record(latency_ms=200, retrieval_hit_ratio=0.9, coverage_score=0.3)
+    snapshot = store.as_dict()
+    assert snapshot["queries_total"] == 2
+    assert snapshot["avg_latency_ms"] > 0
+    assert 0 <= snapshot["retrieval_hits"] <= 1
+
+
+def test_metrics_endpoint_returns_json_payload() -> None:
+    config = DeploymentConfig(
+        mode="local",
+        dataset=Path("data/sample_docs"),
+        index_type="bm25",
+        api_port=8100,
+        ui_port=8600,
+        reranker="coverage",
+    )
+    store = MetricsStore()
+    app = create_app(config=config, metrics_store=store)
+    with TestClient(app) as client:
+        response = client.post("/chat", json={"query": "What is Python?", "top_k": 2})
+        assert response.status_code == 200
+        metrics = client.get("/metrics").json()
+        assert "uptime_seconds" in metrics
+        assert metrics["queries_total"] >= 1
+

--- a/ui/server.py
+++ b/ui/server.py
@@ -1,27 +1,59 @@
-"""FastAPI server exposing chat and query endpoints."""
+"""FastAPI server exposing chat and query endpoints with monitoring hooks."""
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 from pathlib import Path
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Response
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from analysis.redaction import RedactionSettings, TextRedactor
+from configs.loader import DeploymentConfig
 from generation.dummy import EchoGenerator
 from indexing.embedder import get_default_embedder
-from pipelines.chatbot import ChatResponse, RAGPipeline, RetrievalResponse, RetrievalResult
+from monitoring import MetricsStore
+from monitoring.logging import configure_logging
+from pipelines.chatbot import (
+    ChatResponse,
+    RAGPipeline,
+    RetrievalResponse,
+    RetrievalResult,
+)
 
 
-logger = logging.getLogger(__name__)
+class TokenBucket:
+    """Simple token bucket implementation for rate limiting."""
+
+    def __init__(self, rate_per_minute: int, capacity: int | None = None) -> None:
+        self.capacity = capacity or rate_per_minute
+        self.tokens = float(self.capacity)
+        self.rate_per_second = rate_per_minute / 60.0
+        self.updated_at = time.perf_counter()
+
+    def consume(self, tokens: float = 1.0) -> bool:
+        now = time.perf_counter()
+        elapsed = now - self.updated_at
+        self.updated_at = now
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.rate_per_second)
+        if self.tokens >= tokens:
+            self.tokens -= tokens
+            return True
+        return False
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):
-    """Record basic telemetry for each request."""
+    """Record structured telemetry for each request."""
+
+    def __init__(self, app: FastAPI, logger: logging.Logger) -> None:
+        super().__init__(app)
+        self.logger = logger
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         start = time.perf_counter()
@@ -30,17 +62,66 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             body_text = body_bytes.decode("utf-8") if body_bytes else ""
         except Exception:  # pragma: no cover - defensive guard
             body_text = "<unavailable>"
-        logger.info("%s %s payload=%s", request.method, request.url.path, body_text)
+        self.logger.info(
+            "incoming_request",
+            extra={
+                "extra_data": {
+                    "method": request.method,
+                    "path": request.url.path,
+                    "payload": body_text,
+                }
+            },
+        )
         response = await call_next(request)
         duration = time.perf_counter() - start
-        logger.info(
-            "%s %s completed status=%s duration=%.3fs",
-            request.method,
-            request.url.path,
-            getattr(response, "status_code", "unknown"),
-            duration,
+        self.logger.info(
+            "request_complete",
+            extra={
+                "extra_data": {
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status": getattr(response, "status_code", "unknown"),
+                    "duration_ms": round(duration * 1000, 3),
+                }
+            },
         )
         return response
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Guard endpoints behind API key authentication when configured."""
+
+    def __init__(self, app: FastAPI, valid_keys: Iterable[str]) -> None:
+        super().__init__(app)
+        self.valid_keys = {key.strip() for key in valid_keys if key.strip()}
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.url.path in {"/healthz", "/metrics"}:
+            return await call_next(request)
+        key = request.headers.get("X-API-Key")
+        if not key or key not in self.valid_keys:
+            return Response(status_code=401, content="Unauthorized")
+        return await call_next(request)
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Basic token bucket rate limiting."""
+
+    def __init__(self, app: FastAPI, rate_per_minute: int, burst: int | None = None) -> None:
+        super().__init__(app)
+        self.rate = rate_per_minute
+        self.burst = burst or rate_per_minute
+        self.buckets: dict[str, TokenBucket] = {}
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        client_host = getattr(request.client, "host", None)
+        identifier = request.headers.get("X-API-Key") or client_host or "anonymous"
+        bucket = self.buckets.get(identifier)
+        if bucket is None:
+            bucket = self.buckets[identifier] = TokenBucket(self.rate, self.burst)
+        if not bucket.consume():
+            return Response(status_code=429, content="Rate limit exceeded")
+        return await call_next(request)
 
 
 class QueryRequest(BaseModel):
@@ -55,29 +136,77 @@ class ChatRequest(BaseModel):
 
 class AppState:
     pipeline: RAGPipeline | None = None
+    metrics: MetricsStore
+    logger: logging.Logger
+    redactor: TextRedactor | None
+    config: DeploymentConfig | None
 
 
-def create_app(data_path: str | Path = "data/sample_docs") -> FastAPI:
-    logging.basicConfig(level=logging.INFO)
-    base_path = Path(os.environ.get("RAG_DATA_PATH", data_path))
+def _build_pipeline(dataset: Path, index_type: str) -> RAGPipeline:
+    use_faiss = index_type.lower() == "faiss"
+    return RAGPipeline(
+        data_path=dataset,
+        embedder=get_default_embedder(prefer_lightweight=not use_faiss),
+        generator=EchoGenerator(),
+        use_faiss=use_faiss,
+    )
+
+
+def create_app(
+    data_path: str | Path = "data/sample_docs",
+    *,
+    config: DeploymentConfig | None = None,
+    metrics_store: MetricsStore | None = None,
+    logger: logging.Logger | None = None,
+    redactor: TextRedactor | None = None,
+) -> FastAPI:
+    """Create the FastAPI application with monitoring and security hooks."""
+
+    resolved_config = config or DeploymentConfig(
+        mode="local",
+        dataset=Path(os.environ.get("RAG_DATA_PATH", data_path)),
+        index_type="faiss",
+        api_port=8000,
+        ui_port=8501,
+        reranker="coverage",
+    )
+
+    logger = logger or configure_logging(
+        resolved_config.logging.directory if resolved_config.logging else None
+    )
+    metrics = metrics_store or MetricsStore()
     app = FastAPI(title="RAG Chatbot")
     state = AppState()
-    app.add_middleware(LoggingMiddleware)
+    state.metrics = metrics
+    state.logger = logger
+    if redactor is None and resolved_config.enable_redaction:
+        redactor = TextRedactor(RedactionSettings(enable_redaction=True))
+    state.redactor = redactor
+    state.config = resolved_config
+
+    app.add_middleware(LoggingMiddleware, logger=logger)
+    if resolved_config.api_keys:
+        app.add_middleware(APIKeyMiddleware, valid_keys=resolved_config.api_keys)
+    if resolved_config.rate_limit:
+        app.add_middleware(
+            RateLimitMiddleware,
+            rate_per_minute=resolved_config.rate_limit.requests_per_minute,
+            burst=resolved_config.rate_limit.burst,
+        )
 
     @app.on_event("startup")
-    async def startup_event() -> None:
-        await asyncio.get_event_loop().run_in_executor(
-            None,
-            lambda: setattr(
-                state,
-                "pipeline",
-                RAGPipeline(
-                    data_path=base_path,
-                    embedder=get_default_embedder(prefer_lightweight=True),
-                    generator=EchoGenerator(),
-                    use_faiss=False,
-                ),
-            ),
+    async def startup_event() -> None:  # pragma: no cover - exercised in integration tests
+        dataset = resolved_config.dataset
+        pipeline_builder = lambda: _build_pipeline(dataset, resolved_config.index_type)
+        state.pipeline = await asyncio.get_event_loop().run_in_executor(None, pipeline_builder)
+        logger.info(
+            "pipeline_ready",
+            extra={
+                "extra_data": {
+                    "dataset": str(dataset),
+                    "index_type": resolved_config.index_type,
+                }
+            },
         )
 
     @app.post("/query")
@@ -90,6 +219,16 @@ def create_app(data_path: str | Path = "data/sample_docs") -> FastAPI:
                 request.query, top_k=request.top_k
             ),
         )
+        state.metrics.record(
+            latency_ms=retrieval.metrics.get("total_time", 0.0) * 1000,
+            retrieval_hit_ratio=
+            (
+                len(retrieval.results)
+                / max(1.0, retrieval.metrics.get("candidate_count", len(retrieval.results)))
+            ),
+            coverage_score=retrieval.metrics.get("reranker_impact", 0.0),
+        )
+        _record_query_log(state, request.query)
         return {
             "query": retrieval.query,
             "documents": [
@@ -109,6 +248,30 @@ def create_app(data_path: str | Path = "data/sample_docs") -> FastAPI:
             ),
         )
         answer = _append_references(chat_payload.answer, chat_payload.citations)
+        if state.redactor and state.config and state.config.enable_redaction:
+            answer = state.redactor.redact(answer)
+            chat_payload.citations = [
+                {
+                    **citation,
+                    "excerpt": state.redactor.redact(citation.get("excerpt", "")),
+                }
+                for citation in chat_payload.citations
+            ]
+        state.metrics.record(
+            latency_ms=chat_payload.metrics.get("end_to_end_time", 0.0) * 1000,
+            retrieval_hit_ratio=
+            (
+                len(chat_payload.retrieval.results)
+                / max(
+                    1.0,
+                    chat_payload.retrieval.metrics.get(
+                        "candidate_count", len(chat_payload.retrieval.results)
+                    ),
+                )
+            ),
+            coverage_score=chat_payload.retrieval.metrics.get("reranker_impact", 0.0),
+        )
+        _record_query_log(state, request.query)
         return {
             "query": chat_payload.query,
             "answer": answer,
@@ -118,6 +281,15 @@ def create_app(data_path: str | Path = "data/sample_docs") -> FastAPI:
             ],
             "metrics": chat_payload.metrics,
         }
+
+    @app.get("/healthz")
+    async def healthz() -> Dict[str, str]:  # pragma: no cover - trivial
+        status = "ok" if state.pipeline is not None else "starting"
+        return {"status": status}
+
+    @app.get("/metrics")
+    async def metrics_endpoint():
+        return state.metrics.as_dict()
 
     return app
 
@@ -157,3 +329,20 @@ def _append_references(answer: str, citations: list[dict[str, str]]) -> str:
     if "References:" in answer:
         return answer
     return f"{answer}\n\nReferences:\n{references_text}"
+
+
+def _record_query_log(state: AppState, query: str) -> None:
+    config = state.config
+    if not config or not config.logging:
+        return
+    log_dir = config.logging.directory
+    log_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(query.encode("utf-8")).hexdigest()[:12]
+    payload = {
+        "timestamp": time.time(),
+        "query_id": digest,
+        "length": len(query),
+    }
+    log_path = log_dir / "queries.log"
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload) + "\n")


### PR DESCRIPTION
## Summary
- add configuration loader, monitoring utilities, and deployment runtime helpers
- provide local and organisation deployment scripts with sample configs, docs, and load testing tools
- enhance FastAPI server with metrics, rate limiting, API keys, and update CI/Makefile for deployment checks

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68dfa85966f08322b540db1c41dc18e4